### PR TITLE
Improve memory safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ go run .
 
 Launch the application and select the amount of memory and number of threads to stress. Press **Start** to begin the test and **Stop** to end it. Logs are written to `stress_test.log` in the project directory.
 
+### Memory Safety
+
+The tester monitors RAM and swap usage while running. If both become critically low, the stress test stops automatically to prevent crashes. Memory allocation failures are logged and no longer hang the application.
+
 ## GitHub Actions
 
 A workflow file in `.github/workflows/go-build.yml` builds the project automatically on push and pull request for Ubuntu and Windows runners.

--- a/stresstest.go
+++ b/stresstest.go
@@ -57,14 +57,23 @@ func runMemoryTest(ctx context.Context, config TestConfig) {
 			// Log memory allocation attempt
 			logger.LogEvent(fmt.Sprintf("Thread %d: Attempting to allocate %d MB", threadID, memPerThread), logger.EventLog, eventsChan)
 
+			allocSucceeded := false
 			// Try to allocate memory with panic recovery
 			defer func() {
+				if !allocSucceeded {
+					// signal allocation attempt even if failed
+					allocDone <- struct{}{}
+				}
 				if r := recover(); r != nil {
 					logger.LogEvent(fmt.Sprintf("Thread %d: Memory allocation failed: %v", threadID, r), logger.EventError, eventsChan)
+					if config.StopOnError && currentCancel != nil {
+						currentCancel()
+					}
 				}
 			}()
 
 			memory := make([]byte, memSize)
+			allocSucceeded = true
 			memoryBlocks[threadID] = memory // Store reference for cleanup
 
 			// Fill memory with pattern data
@@ -123,6 +132,15 @@ func runMemoryTest(ctx context.Context, config TestConfig) {
 					swapStat, err := mem.SwapMemory()
 					if err != nil {
 						logger.LogEvent(fmt.Sprintf("Thread %d: Error checking swap memory: %v", threadID, err), logger.EventError, eventsChan)
+					}
+
+					// Abort if both RAM and swap are critically low
+					if vmStat.Available < 10*1024*1024 && swapStat.Free < 10*1024*1024 {
+						logger.LogEvent(fmt.Sprintf("Thread %d: Memory critically low, stopping test", threadID), logger.EventError, eventsChan)
+						if currentCancel != nil {
+							currentCancel()
+						}
+						return
 					}
 
 					// Log detailed memory coverage information with formula explanation


### PR DESCRIPTION
## Summary
- prevent allocation hang by always signalling completion and cancelling tests when out of memory
- stop tests automatically when RAM and swap are critically low
- document new memory-safety behavior in README

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/fyne.io/fyne/v2/@v/v2.6.1.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850711c11e083238679117efc37f78b